### PR TITLE
Add Django 1.6 atomic transaction compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ local_settings.py
 /tests/static/collection
 /tests/media
 /docs/_build
+/issues

--- a/src/registration/admin/__init__.py
+++ b/src/registration/admin/__init__.py
@@ -64,6 +64,7 @@ from registration.utils import get_site
 from registration.admin.forms import RegistrationAdminForm
 from registration.compat import import_module
 from registration.compat import force_unicode
+from registration.compat import transaction_atomic
 
 
 csrf_protect_m = method_decorator(csrf_protect)
@@ -339,7 +340,7 @@ class RegistrationAdmin(admin.ModelAdmin):
         return obj
 
     @csrf_protect_m
-    @transaction.commit_on_success
+    @transaction_atomic
     def change_view(self, request, object_id, form_url='', extra_context=None):
         """called for change view
 

--- a/src/registration/compat.py
+++ b/src/registration/compat.py
@@ -44,3 +44,19 @@ try:
     from django.utils.encoding import force_unicode
 except ImportError:
     from django.utils.encoding import force_text as force_unicode
+
+#
+# Django change the transaction strategy from Django 1.6
+# https://docs.djangoproject.com/en/1.6/topics/db/transactions/
+#
+# This change cause issue #15 thus the compatibility importing is required
+#
+# `change_view` in Django 1.6 use transaction.atomic
+# https://github.com/django/django/blob/1.6/django/contrib/admin/options.py#L1186
+# `change_view` in Django 1.5 use commit_on_success
+# https://github.com/django/django/blob/1.5/django/contrib/admin/options.py#L1063
+#
+try:
+    from django.db.transaction import atomic as transaction_atomic
+except ImportError:
+    from django.db.transaction import commit_on_success as transaction_atomic

--- a/src/registration/models.py
+++ b/src/registration/models.py
@@ -51,7 +51,6 @@ import re
 import datetime
 
 from django.db import models
-from django.db import transaction
 from django.contrib.sites.models import Site
 from django.template.loader import render_to_string
 from django.utils.text import ugettext_lazy as _
@@ -63,6 +62,7 @@ from registration.utils import generate_activation_key
 from registration.utils import generate_random_password
 from registration.utils import send_mail
 from registration.supplements import get_supplement_class
+from registration.compat import transaction_atomic
 
 from logging import getLogger
 logger = getLogger(__name__)
@@ -79,7 +79,7 @@ class RegistrationManager(models.Manager):
     expired/rejected inactive accounts.
 
     """
-    @transaction.commit_on_success 
+    @transaction_atomic
     def register(self, username, email, site, send_email=True):
         """register new user with ``username`` and ``email``
 
@@ -110,7 +110,7 @@ class RegistrationManager(models.Manager):
 
         return new_user
 
-    @transaction.commit_on_success 
+    @transaction_atomic
     def accept_registration(self, profile, site, send_email=True, message=None):
         """accept account registration of ``profile``
 
@@ -143,7 +143,7 @@ class RegistrationManager(models.Manager):
             return profile.user
         return None
 
-    @transaction.commit_on_success 
+    @transaction_atomic
     def reject_registration(self, profile, site, send_email=True, message=None):
         """reject account registration of ``profile``
 
@@ -172,7 +172,7 @@ class RegistrationManager(models.Manager):
             return profile.user
         return None
 
-    @transaction.commit_on_success 
+    @transaction_atomic
     def activate_user(self, activation_key, site, password=None,
                       send_email=True, message=None, no_profile_delete=False):
         """activate account with ``activation_key`` and ``password``
@@ -232,7 +232,7 @@ class RegistrationManager(models.Manager):
             return user, password, is_generated
         return None
 
-    @transaction.commit_on_success 
+    @transaction_atomic
     def delete_expired_users(self):
         """delete expired users from database
 
@@ -282,7 +282,7 @@ class RegistrationManager(models.Manager):
                 except User.DoesNotExist:
                     profile.delete()
 
-    @transaction.commit_on_success 
+    @transaction_atomic
     def delete_rejected_users(self):
         """delete rejected users from database
 


### PR DESCRIPTION
To fix issue #15, add atomic transaction compatible codes which introduced from
Django 1.6

Note that somehow the test code (`test_admin.py`) did not raise any
exception even there were the issue #15 thus I'm not really sure this
commit fix the issue #15.
