### PR TITLE
Fix Django 1.8: django.contrib.admin.util is deprecated issue #45

### DIFF
--- a/src/registration/admin/__init__.py
+++ b/src/registration/admin/__init__.py
@@ -48,7 +48,6 @@ import django
 from django.db import transaction
 from django.http import HttpResponseRedirect
 from django.contrib import admin
-from django.contrib.admin.util import unquote
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ImproperlyConfigured
@@ -65,6 +64,7 @@ from registration.admin.forms import RegistrationAdminForm
 from registration.compat import import_module
 from registration.compat import force_unicode
 from registration.compat import transaction_atomic
+from registration.compat import unquote
 
 
 csrf_protect_m = method_decorator(csrf_protect)

--- a/src/registration/compat.py
+++ b/src/registration/compat.py
@@ -22,6 +22,11 @@ except ImportError:
     from django.conf.urls.defaults import patterns
     from django.conf.urls.defaults import include
 
+try:
+    from django.contrib.admin.utils import unquote
+except ImportError:
+    from django.contrib.admin.util import unquote
+
 # Python 2.7 has an importlib with import_module; for older Pythons,
 # Django's bundled copy provides it.
 try:


### PR DESCRIPTION
It will close #45