### PR TITLE
convert the unicode string to a byte string  for Python 2

### DIFF
--- a/src/registration/admin/__init__.py
+++ b/src/registration/admin/__init__.py
@@ -351,7 +351,7 @@ class RegistrationAdmin(admin.ModelAdmin):
             }
             inline_base = get_supplement_admin_inline_base_class()
             inline_form = type(
-                "RegistrationSupplementInlineAdmin",
+                str("RegistrationSupplementInlineAdmin"),
                 (inline_base,), kwargs
             )
             inline_instances = [inline_form(self.model, self.admin_site)]

--- a/src/registration/tests/test_admin.py
+++ b/src/registration/tests/test_admin.py
@@ -412,6 +412,9 @@ class RegistrationAdminTestCase(TestCase):
 
     def test_get_inline_instances_without_supplements(self):
         admin_class = RegistrationAdmin(RegistrationProfile, admin.site)
+        # Prevent caching
+        if hasattr(admin_class.backend, '_supplement_class_cache'):
+            delattr(admin_class.backend, '_supplement_class_cache')
 
         inline_instances = admin_class.get_inline_instances(self.mock_request, None)
         self.assertEqual(len(inline_instances), 0)
@@ -421,6 +424,9 @@ class RegistrationAdminTestCase(TestCase):
     )
     def test_get_inline_instances_with_default_supplements(self):
         admin_class = RegistrationAdmin(RegistrationProfile, admin.site)
+        # Prevent caching
+        if hasattr(admin_class.backend, '_supplement_class_cache'):
+            delattr(admin_class.backend, '_supplement_class_cache')
 
         inline_instances = admin_class.get_inline_instances(self.mock_request, None)
         self.assertEqual(len(inline_instances), 1)

--- a/src/registration/tests/test_admin.py
+++ b/src/registration/tests/test_admin.py
@@ -410,6 +410,7 @@ class RegistrationAdminTestCase(TestCase):
 
         self.assertEqual(RegistrationProfile.objects.count(), 0)
 
+    @override_settings(REGISTRATION_SUPPLEMENT_CLASS=None)
     def test_get_inline_instances_without_supplements(self):
         admin_class = RegistrationAdmin(RegistrationProfile, admin.site)
         # Prevent caching

--- a/src/registration/tests/test_admin.py
+++ b/src/registration/tests/test_admin.py
@@ -410,18 +410,17 @@ class RegistrationAdminTestCase(TestCase):
 
         self.assertEqual(RegistrationProfile.objects.count(), 0)
 
-    def test_get_inline_instances(self):
-        from django.conf import settings
+    def test_get_inline_instances_without_supplements(self):
         admin_class = RegistrationAdmin(RegistrationProfile, admin.site)
 
-        # No supplements
-        settings.REGISTRATION_SUPPLEMENT_CLASS = None
         inline_instances = admin_class.get_inline_instances(self.mock_request, None)
         self.assertEqual(len(inline_instances), 0)
 
-        # Default supplement class
-        settings.REGISTRATION_SUPPLEMENT_CLASS = "registration.supplements.default.models.DefaultRegistrationSupplement"
+    @override_settings(
+        REGISTRATION_SUPPLEMENT_CLASS="registration.supplements.default.models.DefaultRegistrationSupplement"
+    )
+    def test_get_inline_instances_with_default_supplements(self):
+        admin_class = RegistrationAdmin(RegistrationProfile, admin.site)
+
         inline_instances = admin_class.get_inline_instances(self.mock_request, None)
         self.assertEqual(len(inline_instances), 1)
-
-        settings.REGISTRATION_SUPPLEMENT_CLASS = None

--- a/src/registration/tests/test_admin.py
+++ b/src/registration/tests/test_admin.py
@@ -409,3 +409,19 @@ class RegistrationAdminTestCase(TestCase):
             None, RegistrationProfile.objects.all())
 
         self.assertEqual(RegistrationProfile.objects.count(), 0)
+
+    def test_get_inline_instances(self):
+        from django.conf import settings
+        admin_class = RegistrationAdmin(RegistrationProfile, admin.site)
+
+        # No supplements
+        settings.REGISTRATION_SUPPLEMENT_CLASS = None
+        inline_instances = admin_class.get_inline_instances(self.mock_request, None)
+        self.assertEqual(len(inline_instances), 0)
+
+        # Default supplement class
+        settings.REGISTRATION_SUPPLEMENT_CLASS = "registration.supplements.default.models.DefaultRegistrationSupplement"
+        inline_instances = admin_class.get_inline_instances(self.mock_request, None)
+        self.assertEqual(len(inline_instances), 1)
+
+        settings.REGISTRATION_SUPPLEMENT_CLASS = None


### PR DESCRIPTION
six.b is written under the assumption that you won't use unicode_literals
Either don't use unicode_literals, or use str(name). In Python 3, that is a no-op.