### PR TITLE
Django19 + Python3.5 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 install:
-  - pip install tox
+  - pip install tox tox-travis
   - pip install coverage coveralls
 
 script:

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Author
 Supported python versions
     2.6, 2.7, 3.2, 3.3, 3.4
 Supported django versions
-    1.5 - 1.8
+    1.5 - 1.9
 
 django-inspectional-registration is a enhanced application of
 django-registration_. The following features are available

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ django-inspectional-registration
 Author
     Alisue <lambdalisue@hashnote.net>
 Supported python versions
-    2.6, 2.7, 3.2, 3.3, 3.4
+    2.6, 2.7, 3.2, 3.3, 3.4, 3.5
 Supported django versions
     1.5 - 1.9
 

--- a/docs/about_registration_templates.rst
+++ b/docs/about_registration_templates.rst
@@ -29,8 +29,7 @@ Sent when inspector accpet the account registration
         An activation key used to generate activation url. To generate
         activation url, use the following template command::
 
-            {% load url from future %}
-            
+
             http://{{ site.domain }}{% url 'registration_activate' activation_key=activation_key %}
 
     ``expiration_days``
@@ -56,8 +55,7 @@ Sent when inspector accpet the account registration
         An activation key used to generate activation url. To generate
         activation url, use the following template command::
 
-            {% load url from future %}
-            
+
             http://{{ site.domain }}{% url 'registration_activate' activation_key=activation_key %}
 
     ``expiration_days``

--- a/src/registration/contrib/notification/templates/registration/notification_email.txt
+++ b/src/registration/contrib/notification/templates/registration/notification_email.txt
@@ -1,4 +1,3 @@
-{% load url from future %}
 {% load i18n %}
 {% blocktrans with site.name as site_name %}A new registration of {{ site_name }} was created by {{ user }}.{% endblocktrans %}
 

--- a/src/registration/models.py
+++ b/src/registration/models.py
@@ -52,7 +52,6 @@ import re
 import datetime
 
 from django.db import models
-from django.contrib.sites.models import Site
 from django.template.loader import render_to_string
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.text import ugettext_lazy as _
@@ -560,7 +559,6 @@ class RegistrationProfile(models.Model):
             The activation key for tne new account. Use following code to get
             activation url in the email body::
 
-                {% load url from future %}
                 http://{{ site.domain }}
                 {% url 'registration_activate' activation_key=activation_key %}
 

--- a/src/registration/supplements/__init__.py
+++ b/src/registration/supplements/__init__.py
@@ -8,7 +8,6 @@ __all__ = ('RegistrationSupplementBase', 'get_supplement_class')
 from django.core.exceptions import ImproperlyConfigured
 
 from registration.compat import import_module
-from registration.supplements.base import RegistrationSupplementBase
 
 
 def get_supplement_class(path=None):
@@ -39,6 +38,7 @@ def get_supplement_class(path=None):
         raise ImproperlyConfigured((
                 'Module "%s" does not define a registration supplement named '
                 '"%s"') % (module, attr))
+    from registration.supplements.base import RegistrationSupplementBase
     if cls and not issubclass(cls, RegistrationSupplementBase):
         raise ImproperlyConfigured((
             'Registration supplement class "%s" must be a subclass of '

--- a/src/registration/supplements/default/models.py
+++ b/src/registration/supplements/default/models.py
@@ -7,7 +7,7 @@ __author__ = 'Alisue <lambdalisue@hashnote.net>'
 from django.db import models
 from django.utils.text import ugettext_lazy as _
 from django.utils.encoding import python_2_unicode_compatible
-from registration.supplements import RegistrationSupplementBase
+from registration.supplements.base import RegistrationSupplementBase
 
 
 @python_2_unicode_compatible

--- a/src/registration/templates/admin/registration/registrationprofile/change_form.html
+++ b/src/registration/templates/admin/registration/registrationprofile/change_form.html
@@ -1,5 +1,4 @@
 {% extends "admin/change_form.html" %}
-{% load url from future %}
 {% load i18n %}
 
 {% block content_title %}

--- a/src/registration/templates/registration/acceptance_email.txt
+++ b/src/registration/templates/registration/acceptance_email.txt
@@ -1,4 +1,3 @@
-{% load url from future %}
 {% load i18n %}
 {% blocktrans %}Dear {{ user }},{% endblocktrans %}
 

--- a/src/registration/templates/registration/activation_complete.html
+++ b/src/registration/templates/registration/activation_complete.html
@@ -1,5 +1,4 @@
 {% extends 'registration/base.html' %}
-{% load url from future %}
 {% load i18n %}
 
 {% block title %}{% trans 'Activation was complete' %}{% endblock %}

--- a/src/registration/templates/registration/activation_email.txt
+++ b/src/registration/templates/registration/activation_email.txt
@@ -1,4 +1,3 @@
-{% load url from future %}
 {% load i18n %}
 {% blocktrans %}Dear {{ user }},{% endblocktrans %}
 {% if is_generated %}

--- a/src/registration/templates/registration/activation_form.html
+++ b/src/registration/templates/registration/activation_form.html
@@ -1,5 +1,4 @@
 {% extends 'registration/base.html' %}
-{% load url from future %}
 {% load i18n %}
 
 {% block title %}{% trans 'Activate your account' %}{% endblock %}

--- a/src/registration/templates/registration/base.html
+++ b/src/registration/templates/registration/base.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <!DOCTYPE html>
 <html>
 <head>

--- a/src/registration/templates/registration/login.html
+++ b/src/registration/templates/registration/login.html
@@ -1,5 +1,4 @@
 {% extends 'registration/base.html' %}
-{% load url from future %}
 {% load i18n %}
 
 {% block title %}{% trans 'Login' %}{% endblock %}

--- a/src/registration/templates/registration/logout.html
+++ b/src/registration/templates/registration/logout.html
@@ -1,5 +1,4 @@
 {% extends 'registration/base.html' %}
-{% load url from future %}
 {% load i18n %}
 
 {% block title %}{% trans 'Logged out' %}{% endblock %}

--- a/src/registration/templates/registration/registration_closed.html
+++ b/src/registration/templates/registration/registration_closed.html
@@ -1,5 +1,4 @@
 {% extends 'registration/base.html' %}
-{% load url from future %}
 {% load i18n %}
 
 {% block title %}{% trans 'Registration is closed' %}{% endblock %}

--- a/src/registration/templates/registration/registration_complete.html
+++ b/src/registration/templates/registration/registration_complete.html
@@ -1,5 +1,4 @@
 {% extends 'registration/base.html' %}
-{% load url from future %}
 {% load i18n %}
 
 {% block title %}{% trans 'Registration was complete' %}{% endblock %}

--- a/src/registration/templates/registration/registration_email.txt
+++ b/src/registration/templates/registration/registration_email.txt
@@ -1,4 +1,3 @@
-{% load url from future %}
 {% load i18n %}
 {% blocktrans %}Dear {{ user }},{% endblocktrans %}
 {% trans 'Your account registration was created successfully.' %}

--- a/src/registration/templates/registration/registration_form.html
+++ b/src/registration/templates/registration/registration_form.html
@@ -1,5 +1,4 @@
 {% extends 'registration/base.html' %}
-{% load url from future %}
 {% load i18n %}
 
 {% block title %}{% trans 'Registration' %}{% endblock %}

--- a/src/registration/templates/registration/rejection_email.txt
+++ b/src/registration/templates/registration/rejection_email.txt
@@ -1,4 +1,3 @@
-{% load url from future %}
 {% load i18n %}
 {% blocktrans %}Dear {{ user }},{% endblocktrans %}
 

--- a/src/registration/tests/test_admin.py
+++ b/src/registration/tests/test_admin.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from django.contrib import admin
 from django.core.urlresolvers import reverse
 from django.core import mail
+from django.core import urlresolvers
 from registration.compat import get_user_model
 from registration.backends.default import DefaultRegistrationBackend
 from registration.models import RegistrationProfile
@@ -36,7 +37,7 @@ class RegistrationAdminTestCase(TestCase):
         self.admin_url = reverse('admin:index')
 
     def test_change_list_view_get(self):
-        url = self.admin_url + "registration/registrationprofile/"
+        url = urlresolvers.reverse('admin:registration_registrationprofile_changelist')
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 200)
@@ -48,7 +49,7 @@ class RegistrationAdminTestCase(TestCase):
             username='bob', email='bob@example.com',
             request=self.mock_request)
 
-        url = self.admin_url + "registration/registrationprofile/1/"
+        url = urlresolvers.reverse('admin:registration_registrationprofile_change', args=(1,))
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 200)
@@ -62,7 +63,7 @@ class RegistrationAdminTestCase(TestCase):
             username='bob', email='bob@example.com',
             request=self.mock_request)
 
-        url = self.admin_url + "registration/registrationprofile/100/"
+        url = urlresolvers.reverse('admin:registration_registrationprofile_change', args=(100,))
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 404)
@@ -72,8 +73,8 @@ class RegistrationAdminTestCase(TestCase):
             username='bob', email='bob@example.com',
             request=self.mock_request)
 
-        url = self.admin_url + "registration/registrationprofile/1/"
-        redirect_url = self.admin_url + "registration/registrationprofile/"
+        url = urlresolvers.reverse('admin:registration_registrationprofile_change', args=(1,))
+        redirect_url = urlresolvers.reverse('admin:registration_registrationprofile_changelist')
         response = self.client.post(url, {
             '_supplement-TOTAL_FORMS': 0,
             '_supplement-INITIAL_FORMS': 0,
@@ -95,8 +96,8 @@ class RegistrationAdminTestCase(TestCase):
             new_user.registration_profile,
             request=self.mock_request)
         previous_activation_key = new_user.registration_profile.activation_key
-        url = self.admin_url + "registration/registrationprofile/1/"
-        redirect_url = self.admin_url + "registration/registrationprofile/"
+        url = urlresolvers.reverse('admin:registration_registrationprofile_change', args=(1,))
+        redirect_url = urlresolvers.reverse('admin:registration_registrationprofile_changelist')
         response = self.client.post(url, {
             '_supplement-TOTAL_FORMS': 0,
             '_supplement-INITIAL_FORMS': 0,
@@ -119,8 +120,8 @@ class RegistrationAdminTestCase(TestCase):
             new_user.registration_profile,
             request=self.mock_request)
 
-        url = self.admin_url + "registration/registrationprofile/1/"
-        redirect_url = self.admin_url + "registration/registrationprofile/"
+        url = urlresolvers.reverse('admin:registration_registrationprofile_change', args=(1,))
+        redirect_url = urlresolvers.reverse('admin:registration_registrationprofile_changelist')
         response = self.client.post(url, {
             '_supplement-TOTAL_FORMS': 0,
             '_supplement-INITIAL_FORMS': 0,
@@ -139,8 +140,8 @@ class RegistrationAdminTestCase(TestCase):
             username='bob', email='bob@example.com',
             request=self.mock_request)
 
-        url = self.admin_url + "registration/registrationprofile/1/"
-        redirect_url = self.admin_url + "registration/registrationprofile/"
+        url = urlresolvers.reverse('admin:registration_registrationprofile_change', args=(1,))
+        redirect_url = urlresolvers.reverse('admin:registration_registrationprofile_changelist')
         response = self.client.post(url, {
             '_supplement-TOTAL_FORMS': 0,
             '_supplement-INITIAL_FORMS': 0,
@@ -162,7 +163,7 @@ class RegistrationAdminTestCase(TestCase):
             new_user.registration_profile,
             request=self.mock_request)
 
-        url = self.admin_url + "registration/registrationprofile/1/"
+        url = urlresolvers.reverse('admin:registration_registrationprofile_change', args=(1,))
         response = self.client.post(url, {
             '_supplement-TOTAL_FORMS': 0,
             '_supplement-INITIAL_FORMS': 0,
@@ -192,7 +193,7 @@ class RegistrationAdminTestCase(TestCase):
             new_user.registration_profile,
             request=self.mock_request)
 
-        url = self.admin_url + "registration/registrationprofile/1/"
+        url = urlresolvers.reverse('admin:registration_registrationprofile_change', args=(1,))
         response = self.client.post(url, {
             '_supplement-TOTAL_FORMS': 0,
             '_supplement-INITIAL_FORMS': 0,
@@ -219,7 +220,7 @@ class RegistrationAdminTestCase(TestCase):
             username='bob', email='bob@example.com',
             request=self.mock_request)
 
-        url = self.admin_url + "registration/registrationprofile/1/"
+        url = urlresolvers.reverse('admin:registration_registrationprofile_change', args=(1,))
         response = self.client.post(url, {
             '_supplement-TOTAL_FORMS': 0,
             '_supplement-INITIAL_FORMS': 0,
@@ -249,8 +250,8 @@ class RegistrationAdminTestCase(TestCase):
             new_user.registration_profile,
             request=self.mock_request)
 
-        url = self.admin_url + "registration/registrationprofile/1/"
-        redirect_url = self.admin_url + "registration/registrationprofile/"
+        url = urlresolvers.reverse('admin:registration_registrationprofile_change', args=(1,))
+        redirect_url = urlresolvers.reverse('admin:registration_registrationprofile_changelist')
         response = self.client.post(url, {
             '_supplement-TOTAL_FORMS': 0,
             '_supplement-INITIAL_FORMS': 0,
@@ -272,7 +273,7 @@ class RegistrationAdminTestCase(TestCase):
             new_user.registration_profile,
             request=self.mock_request)
 
-        url = self.admin_url + "registration/registrationprofile/1/"
+        url = urlresolvers.reverse('admin:registration_registrationprofile_change', args=(1,))
         response = self.client.post(url, {
             '_supplement-TOTAL_FORMS': 0,
             '_supplement-INITIAL_FORMS': 0,
@@ -299,8 +300,8 @@ class RegistrationAdminTestCase(TestCase):
             username='bob', email='bob@example.com',
             request=self.mock_request)
 
-        url = self.admin_url + "registration/registrationprofile/1/"
-        redirect_url = self.admin_url + "registration/registrationprofile/"
+        url = urlresolvers.reverse('admin:registration_registrationprofile_change', args=(1,))
+        redirect_url = urlresolvers.reverse('admin:registration_registrationprofile_changelist')
         response = self.client.post(url, {
             '_supplement-TOTAL_FORMS': 0,
             '_supplement-INITIAL_FORMS': 0,
@@ -322,7 +323,7 @@ class RegistrationAdminTestCase(TestCase):
             new_user.registration_profile,
             request=self.mock_request)
 
-        url = self.admin_url + "registration/registrationprofile/1/"
+        url = urlresolvers.reverse('admin:registration_registrationprofile_change', args=(1,))
         response = self.client.post(url, {
             '_supplement-TOTAL_FORMS': 0,
             '_supplement-INITIAL_FORMS': 0,
@@ -352,8 +353,8 @@ class RegistrationAdminTestCase(TestCase):
             new_user.registration_profile,
             request=self.mock_request)
 
-        url = self.admin_url + "registration/registrationprofile/1/"
-        redirect_url = self.admin_url + "registration/registrationprofile/"
+        url = urlresolvers.reverse('admin:registration_registrationprofile_change', args=(1,))
+        redirect_url = urlresolvers.reverse('admin:registration_registrationprofile_changelist')
         response = self.client.post(url, {
             '_supplement-TOTAL_FORMS': 0,
             '_supplement-INITIAL_FORMS': 0,

--- a/src/registration/tests/test_supplements.py
+++ b/src/registration/tests/test_supplements.py
@@ -9,7 +9,6 @@ from django.core.urlresolvers import reverse
 from django.core.exceptions import ImproperlyConfigured
 
 from registration import forms
-from registration.conf import settings
 from registration.supplements import get_supplement_class
 from registration.models import RegistrationProfile
 from registration.tests.utils import with_apps
@@ -46,20 +45,6 @@ class RegistrationSupplementRetrievalTests(TestCase):
             'registration.backends.default.DefaultRegistrationBackend'),
     )
 class RegistrationViewWithDefaultRegistrationSupplementTestCase(TestCase):
-    def setUp(self):
-        from registration.tests.utils import recall_syncdb
-        from registration.tests.utils import clear_all_meta_caches
-        # recall syncdb
-        recall_syncdb()
-        try:
-            # clear caches
-            clear_all_meta_caches()
-            from django.db.models import loading
-            loading.cache.loaded = False
-        except ImportError:
-            # In Django1.9, django.db.models.loading is removed
-            pass
-
     def test_registration_view_get(self):
         """
         A ``GET`` to the ``register`` view uses the appropriate

--- a/src/registration/tests/test_supplements.py
+++ b/src/registration/tests/test_supplements.py
@@ -51,10 +51,14 @@ class RegistrationViewWithDefaultRegistrationSupplementTestCase(TestCase):
         from registration.tests.utils import clear_all_meta_caches
         # recall syncdb
         recall_syncdb()
-        # clear caches
-        clear_all_meta_caches()
-        from django.db.models import loading
-        loading.cache.loaded = False
+        try:
+            # clear caches
+            clear_all_meta_caches()
+            from django.db.models import loading
+            loading.cache.loaded = False
+        except ImportError:
+            # In Django1.9, django.db.models.loading is removed
+            pass
 
     def test_registration_view_get(self):
         """

--- a/src/registration/tests/utils.py
+++ b/src/registration/tests/utils.py
@@ -5,27 +5,6 @@ from __future__ import unicode_literals
 __author__ = 'Alisue <lambdalisue@hashnote.net>'
 
 
-def clear_meta_caches(model):
-    """clear model meta caches. it is required to refresh m2m relation"""
-    CACHE_NAMES = (
-            '_m2m_cache', '_field_cache', '_name_map',
-            '_related_objects_cache', '_related_many_to_many_cache'
-        )
-    for name in CACHE_NAMES:
-        if hasattr(model._meta, name):
-            delattr(model._meta, name)
-
-def clear_all_meta_caches():
-    """clear all models meta caches by contenttype
-    
-    .. Note::
-        'django.contrib.contenttypes' is required to installed
-
-    """
-    from django.contrib.contenttypes.models import ContentType
-    for ct in ContentType.objects.iterator():
-        clear_meta_caches(ct.model_class())
-
 def with_apps(*apps):
     """
     Class decorator that makes sure the passed apps are present in

--- a/src/registration/tests/utils.py
+++ b/src/registration/tests/utils.py
@@ -6,9 +6,13 @@ __author__ = 'Alisue <lambdalisue@hashnote.net>'
 
 def recall_syncdb():
     """call ``syncdb`` command to create tables of new app's models"""
-    from django.db.models import loading
     from django.core.management import call_command
-    loading.cache.loaded = False
+    try:
+        from django.db.models import loading
+        loading.cache.loaded = False
+    except ImportError:
+        # In Django1.9, django.db.models.loading is removed
+        pass
     call_command('syncdb', interactive=False, verbosity=0, migrate=False, migrate_all=True)
 
 def clear_meta_caches(model):

--- a/src/registration/tests/utils.py
+++ b/src/registration/tests/utils.py
@@ -3,23 +3,6 @@ from __future__ import unicode_literals
 """
 """
 __author__ = 'Alisue <lambdalisue@hashnote.net>'
-from django.core.management.base import CommandError
-
-
-def recall_syncdb():
-    """call ``syncdb`` command to create tables of new app's models"""
-    from django.core.management import call_command
-    try:
-        from django.db.models import loading
-        loading.cache.loaded = False
-    except ImportError:
-        # In Django1.9, django.db.models.loading is removed
-        pass
-    try:
-        call_command('syncdb', interactive=False, verbosity=0, migrate=False, migrate_all=True)
-    except CommandError:
-        # In Django1.9, syncdb command is removed
-        pass
 
 
 def clear_meta_caches(model):

--- a/src/registration/tests/utils.py
+++ b/src/registration/tests/utils.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 """
 """
 __author__ = 'Alisue <lambdalisue@hashnote.net>'
+from django.core.management.base import CommandError
+
 
 def recall_syncdb():
     """call ``syncdb`` command to create tables of new app's models"""
@@ -13,7 +15,12 @@ def recall_syncdb():
     except ImportError:
         # In Django1.9, django.db.models.loading is removed
         pass
-    call_command('syncdb', interactive=False, verbosity=0, migrate=False, migrate_all=True)
+    try:
+        call_command('syncdb', interactive=False, verbosity=0, migrate=False, migrate_all=True)
+    except CommandError:
+        # In Django1.9, syncdb command is removed
+        pass
+
 
 def clear_meta_caches(model):
     """clear model meta caches. it is required to refresh m2m relation"""

--- a/src/registration/utils.py
+++ b/src/registration/utils.py
@@ -19,6 +19,11 @@ def get_site(request):
 
     """
     from django.contrib.sites.models import Site
+    try:
+        from django.contrib.sites.models import RequestSite
+    except ImportError:
+        from django.contrib.sites.requests import RequestSite
+
     if Site._meta.installed:
         return Site.objects.get_current()
     else:

--- a/src/registration/utils.py
+++ b/src/registration/utils.py
@@ -6,8 +6,6 @@ Utilities for django-inspectional-registration
 __author__ = 'Alisue <lambdalisue@hashnote.net>'
 import random
 
-from django.contrib.sites.models import Site
-from django.contrib.sites.models import RequestSite
 from django.utils.encoding import force_text
 from django.utils.six.moves import range
 from registration.compat import sha1
@@ -20,6 +18,7 @@ def get_site(request):
     not installed.
 
     """
+    from django.contrib.sites.models import Site
     if Site._meta.installed:
         return Site.objects.get_current()
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,18 @@
 [tox]
 envlist =
-    {py26,py27}-django{15,16},
-    {py27}-django{17,18,19},
-    {py33,py34}-django{15,16,17,18},
-    {py34}-django{15,16,17,18,19},
+    py26-django{15,16},
+    py27-django{15,16,17,18,19},
+    py33-django{15,16,17,18},
+    py34-django{15,16,17,18,19},
+    py35-django{18,19},
     docs
 
 [tox:travis]
-2.6 = py26-django{12,13,14,15,16}
-2.7 = py27-django{12,13,14,15,16,17,18,19}
-3.2 = py33-django{15,16,17,18}
+2.6 = py26-django{15,16}
+2.7 = py27-django{15,16,17,18,19}
 3.3 = py33-django{15,16,17,18}
 3.4 = py34-django{15,16,17,18,19}
+3.5 = py35-django{18,19}
 
 [testenv]
 basepython =
@@ -19,6 +20,7 @@ basepython =
     py27: python2.7
     py33: python3.3
     py34: python3.4
+    py35: python3.5
 deps=
     django15: django>=1.5,<1.6
     django16: django>=1.6,<1.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
     {py26,py27}-django{15,16},
-    {py27}-django{17,18},
+    {py27}-django{17,18,19},
     {py33,py34}-django{15,16,17,18},
+    {py34}-django{15,16,17,18,19},
     docs
 
 [testenv]
@@ -16,6 +17,7 @@ deps=
     django16: django>=1.6,<1.7
     django17: django>=1.7,<1.8
     django18: django>=1.8,<1.9
+    django19: django>=1.9,<1.10
     -rrequirements-test.txt
     coverage
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,13 @@ envlist =
     {py34}-django{15,16,17,18,19},
     docs
 
+[tox:travis]
+2.6 = py26-django{12,13,14,15,16}
+2.7 = py27-django{12,13,14,15,16,17,18,19}
+3.2 = py33-django{15,16,17,18}
+3.3 = py33-django{15,16,17,18}
+3.4 = py34-django{15,16,17,18,19}
+
 [testenv]
 basepython =
     py26: python2.6


### PR DESCRIPTION
closes #53 

I followed these incompatibilities. :facepunch: 

- Load models lazily to avoid `AppResistoryNotReady`
- Admin site URLs are modified
    - Use Reversing Admin URL instead of hard cording
    - https://docs.djangoproject.com/en/1.9/ref/contrib/admin/#admin-reverse-urls
- `db.models.loading` is removed
- syncdb command is removed
- `contrib.site.models.RequestSite` is moved
- Remove `url` templatetag from `future` library

For detail, see Django 1.9 Release note

https://docs.djangoproject.com/en/1.9/releases/1.9/