### PR TITLE
fix docs, v0.6.0 breaks with `registration.supplements` import

### DIFF
--- a/docs/about_registration_supplement.rst
+++ b/docs/about_registration_supplement.rst
@@ -24,7 +24,7 @@ Quick tutorial to create your own Registration Supplement
         from __future__ import unicode_literals
         from django.db import models
         from django.utils.encoding import python_2_unicode_compatible
-        from registration.supplements import RegistrationSupplementBase
+        from registration.supplements.base import RegistrationSupplementBase
 
         class MyRegistrationSupplement(RegistrationSupplementBase):
             


### PR DESCRIPTION
The import `from registration.supplements.base import RegistrationSupplementBase` breaks after version 0.6.0.

https://github.com/kawazrepos/Kawaz3rd/commit/d03fcb750bdf5fe42b32790b890cdfd08234147d