### PR TITLE
Use classed based views for Django 1.11

### DIFF
--- a/src/registration/urls.py
+++ b/src/registration/urls.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 URLconf for django-inspectional-registration
 """
 __author__ = 'Alisue <lambdalisue@hashnote.net>'
+import django
 from registration.compat import url
 
 from registration.views import RegistrationView
@@ -32,7 +33,6 @@ if settings.REGISTRATION_DJANGO_AUTH_URLS_ENABLE:
     prefix = settings.REGISTRATION_DJANGO_AUTH_URL_NAMES_PREFIX
     suffix = settings.REGISTRATION_DJANGO_AUTH_URL_NAMES_SUFFIX
 
-    import django
     if django.VERSION >= (1, 6):
         uidb = r"(?P<uidb64>[0-9A-Za-z_\-]+)"
         token = r"(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})"
@@ -46,30 +46,54 @@ if settings.REGISTRATION_DJANGO_AUTH_URLS_ENABLE:
             r"^password/reset/confirm/%s-%s/$" % (uidb, token)
         )
 
-    urlpatterns += [
-        url(r'^login/$', auth_views.login,
-            {'template_name': 'registration/login.html'},
-            name=prefix+'login'+suffix),
-        url(r'^logout/$', auth_views.logout,
-            {'template_name': 'registration/logout.html'},
-            name=prefix+'logout'+suffix),
-        url(r'^password/change/$', auth_views.password_change,
-            name=prefix+'password_change'+suffix),
-        url(r'^password/change/done/$', auth_views.password_change_done,
-            name=prefix+'password_change_done'+suffix),
-        url(r'^password/reset/$', auth_views.password_reset,
-            name=prefix+'password_reset'+suffix, kwargs=dict(
-                post_reset_redirect=prefix+'password_reset_done'+suffix)),
-        url(password_reset_confirm_rule,
-            auth_views.password_reset_confirm,
-            name=prefix+'password_reset_confirm'+suffix),
-        url(r'^password/reset/complete/$', auth_views.password_reset_complete,
-            name=prefix+'password_reset_complete'+suffix),
-        url(r'^password/reset/done/$', auth_views.password_reset_done,
-            name=prefix+'password_reset_done'+suffix),
-    ]
+    if django.VERSION >= (1, 11):
+        urlpatterns += [
+            url(r'^login/$', auth_views.LoginView.as_view(
+                template_name='registration/login.html'),
+                name=prefix+'login'+suffix),
+            url(r'^logout/$', auth_views.LogoutView.as_view(
+                template_name='registration/logout.html'),
+                name=prefix+'logout'+suffix),
+            url(r'^password/change/$', auth_views.PasswordChangeView.as_view(),
+                name=prefix+'password_change'+suffix),
+            url(r'^password/change/done/$', auth_views.PasswordChangeDoneView.as_view(),
+                name=prefix+'password_change_done'+suffix),
+            url(r'^password/reset/$', auth_views.PasswordResetView.as_view(
+                success_url=prefix+'password_reset_done'+suffix),
+                name=prefix+'password_reset'+suffix),
+            url(password_reset_confirm_rule,
+                auth_views.PasswordResetConfirmView.as_view(),
+                name=prefix+'password_reset_confirm'+suffix),
+            url(r'^password/reset/complete/$', auth_views.PasswordResetCompleteView.as_view(),
+                name=prefix+'password_reset_complete'+suffix),
+            url(r'^password/reset/done/$', auth_views.PasswordResetDoneView.as_view(),
+                name=prefix+'password_reset_done'+suffix),
+        ]
+    else:
+        urlpatterns += [
+            url(r'^login/$', auth_views.login,
+                {'template_name': 'registration/login.html'},
+                name=prefix+'login'+suffix),
+            url(r'^logout/$', auth_views.logout,
+                {'template_name': 'registration/logout.html'},
+                name=prefix+'logout'+suffix),
+            url(r'^password/change/$', auth_views.password_change,
+                name=prefix+'password_change'+suffix),
+            url(r'^password/change/done/$', auth_views.password_change_done,
+                name=prefix+'password_change_done'+suffix),
+            url(r'^password/reset/$', auth_views.password_reset,
+                name=prefix+'password_reset'+suffix, kwargs=dict(
+                    post_reset_redirect=prefix+'password_reset_done'+suffix)),
+            url(password_reset_confirm_rule,
+                auth_views.password_reset_confirm,
+                name=prefix+'password_reset_confirm'+suffix),
+            url(r'^password/reset/complete/$', auth_views.password_reset_complete,
+                name=prefix+'password_reset_complete'+suffix),
+            url(r'^password/reset/done/$', auth_views.password_reset_done,
+                name=prefix+'password_reset_done'+suffix),
+        ]
 
-import django
+
 if django.VERSION <= (1, 8):
     from registration.compat import patterns
     urlpatterns = patterns('', *urlpatterns)


### PR DESCRIPTION
Fixes #80 for Django 1.11. For other versions of django a fix is needed in `password_reset_confirm.html` to add the tag `<meta name="referrer" content="never">` and `rel="noreferrer"` should be added to the anchor tag in `password_reset_email.html`. I didn't see either of these templates in the repository, so it may be best to just warn users of the issue of potentially leaking the reset token through the `Referrer` header.